### PR TITLE
Fixed nested validation on arrays outputting incorrectly

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+**0.6.0**
+
+* breaking change with `@ValidateNested` on arrays: Validator now groups the validation errors by sub-object, rather than them all being grouped together. See #32 for a demonstration of the updated structure.
+
 **0.5.0**
 
 * async validations must be marked with `{ async: true }` option now.

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -169,7 +169,28 @@ export class ValidationExecutor {
             const targetSchema = typeof metadata.target === "string" ? metadata.target as string : undefined;
 
             if (value instanceof Array) {
-                value.forEach((subValue: any) => this.execute(subValue, targetSchema, errors));
+                value.forEach((subValue: any, index: number) => {
+                    const validationError = new ValidationError();
+
+                    if (!this.validatorOptions ||
+                        !this.validatorOptions.validationError ||
+                        this.validatorOptions.validationError.target === undefined ||
+                        this.validatorOptions.validationError.target === true)
+                        validationError.target = value;
+
+                    if (!this.validatorOptions ||
+                        !this.validatorOptions.validationError ||
+                        this.validatorOptions.validationError.value === undefined ||
+                        this.validatorOptions.validationError.value === true)
+                        validationError.value = subValue;
+
+                    validationError.property = index.toString();
+                    validationError.children = [];
+                    validationError.constraints = {};
+                    errors.push(validationError);
+
+                    this.execute(subValue, targetSchema, validationError.children)
+                });
 
             } else if (value instanceof Object) {
                 this.execute(value, targetSchema, errors);

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -51,23 +51,7 @@ export class ValidationExecutor {
             const customValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CUSTOM_VALIDATION);
             const nestedValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.NESTED_VALIDATION);
 
-            const validationError = new ValidationError();
-
-            if (!this.validatorOptions ||
-                !this.validatorOptions.validationError ||
-                this.validatorOptions.validationError.target === undefined ||
-                this.validatorOptions.validationError.target === true)
-                validationError.target = object;
-
-            if (!this.validatorOptions ||
-                !this.validatorOptions.validationError ||
-                this.validatorOptions.validationError.value === undefined ||
-                this.validatorOptions.validationError.value === true)
-                validationError.value = value;
-
-            validationError.property = propertyName;
-            validationError.children = [];
-            validationError.constraints = {};
+            const validationError = this.generateValidationError(object, value, propertyName);
             validationErrors.push(validationError);
 
             // handle IS_DEFINED validation type the special way - it should work no matter skipMissingProperties is set or not
@@ -104,6 +88,28 @@ export class ValidationExecutor {
     // -------------------------------------------------------------------------
     // Private Methods
     // -------------------------------------------------------------------------
+
+    private generateValidationError(object: Object, value: any, propertyName: string) {
+        const validationError = new ValidationError();
+
+        if (!this.validatorOptions ||
+            !this.validatorOptions.validationError ||
+            this.validatorOptions.validationError.target === undefined ||
+            this.validatorOptions.validationError.target === true)
+            validationError.target = object;
+
+        if (!this.validatorOptions ||
+            !this.validatorOptions.validationError ||
+            this.validatorOptions.validationError.value === undefined ||
+            this.validatorOptions.validationError.value === true)
+            validationError.value = value;
+
+        validationError.property = propertyName;
+        validationError.children = [];
+        validationError.constraints = {};
+
+        return validationError;
+    }
 
     private defaultValidations(object: Object,
                                value: any,
@@ -170,26 +176,10 @@ export class ValidationExecutor {
 
             if (value instanceof Array) {
                 value.forEach((subValue: any, index: number) => {
-                    const validationError = new ValidationError();
-
-                    if (!this.validatorOptions ||
-                        !this.validatorOptions.validationError ||
-                        this.validatorOptions.validationError.target === undefined ||
-                        this.validatorOptions.validationError.target === true)
-                        validationError.target = value;
-
-                    if (!this.validatorOptions ||
-                        !this.validatorOptions.validationError ||
-                        this.validatorOptions.validationError.value === undefined ||
-                        this.validatorOptions.validationError.value === true)
-                        validationError.value = subValue;
-
-                    validationError.property = index.toString();
-                    validationError.children = [];
-                    validationError.constraints = {};
+                    const validationError = this.generateValidationError(value, subValue, index.toString());
                     errors.push(validationError);
 
-                    this.execute(subValue, targetSchema, validationError.children)
+                    this.execute(subValue, targetSchema, validationError.children);
                 });
 
             } else if (value instanceof Object) {

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -64,10 +64,14 @@ describe("nested validation", function() {
             errors[2].value.should.be.equal(model.mySubClasses);
             expect(errors[2].constraints).to.be.undefined;
             const subError2 = errors[2].children[0];
-            subError2.target.should.be.equal(model.mySubClasses[0]);
-            subError2.property.should.be.equal("name");
-            subError2.constraints.should.be.eql({ minLength: "name must be longer than 5 characters" });
-            subError2.value.should.be.equal("my");
+            subError2.target.should.be.equal(model.mySubClasses);
+            subError2.value.should.be.equal(model.mySubClasses[0]);
+            subError2.property.should.be.equal("0");
+            const subSubError = subError2.children[0];
+            subSubError.target.should.be.equal(model.mySubClasses[0]);
+            subSubError.property.should.be.equal("name");
+            subSubError.constraints.should.be.eql({ minLength: "name must be longer than 5 characters" });
+            subSubError.value.should.be.equal("my");
         });
     });
 


### PR DESCRIPTION
There is a bug in nested validation - when doing nested validation on an array, the validation errors are added directly to the children of the property itself. This means that errors in different objects all appear in the same place.

This PR changes the behaviour such that each child object is given its own error (with the propertyName being their index in the original array) and its children are kept separate from the others.

Let me know if this isn't actually the expected behaviour, or whether my implementation of the fix isn't ideal.