### PR TITLE
feat: ValidateIf decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,26 @@ export class Post {
 }
 ```
 
+## Conditional validation
+
+The conditional validation decorator (`@ValidateIf`) can be used to ignore the validators on a property when the provided condition function returns false. The condition function takes the object being validated and must return a `boolean`.
+
+```typescript
+import {ValidateIf, IsNotEmpty} from "class-validator";
+
+export class Post {
+    otherProperty:string;
+    
+    @ValidateIf(o => o.otherProperty === "value")
+    @IsNotEmpty()
+    example:string;
+}
+```
+
+In the example above, the validation rules applied to `example` won't be run unless the object's `otherProperty` is `"value"`.
+
+Note that when the condition is false all validation decorators are ignored, including `isDefined`.
+
 ## Skipping missing properties
 
 Sometimes you may want to skip validation of the properties that does not exist in the validating object. This is

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,5 +1,9 @@
 # Release notes
 
+**0.6.0**
+
+* added `@ValidateIf` decorator, see conditional validation in docs.
+
 **0.5.0**
 
 * async validations must be marked with `{ async: true }` option now.

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -63,6 +63,22 @@ export function ValidateNested(validationOptions?: ValidationOptions) {
     };
 }
 
+/**
+ * Objects / object arrays marked with this decorator will also be validated.
+ */
+export function ValidateIf(condition: (object: any, value: any) => boolean, validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.CONDITIONAL_VALIDATION,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [condition],
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
 // -------------------------------------------------------------------------
 // Common checkers
 // -------------------------------------------------------------------------

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -50,7 +50,7 @@ export class ValidationExecutor {
             const metadatas = groupedMetadatas[propertyName].filter(metadata => metadata.type !== ValidationTypes.IS_DEFINED);
             const customValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CUSTOM_VALIDATION);
             const nestedValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.NESTED_VALIDATION);
-            const conditionalValidationMetadatas = metadatas.filter(metadata => metadata.type == ValidationTypes.CONDITIONAL_VALIDATION);
+            const conditionalValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CONDITIONAL_VALIDATION);
 
             const validationError = this.generateValidationError(object, value, propertyName);
             validationErrors.push(validationError);

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -50,9 +50,15 @@ export class ValidationExecutor {
             const metadatas = groupedMetadatas[propertyName].filter(metadata => metadata.type !== ValidationTypes.IS_DEFINED);
             const customValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.CUSTOM_VALIDATION);
             const nestedValidationMetadatas = metadatas.filter(metadata => metadata.type === ValidationTypes.NESTED_VALIDATION);
+            const conditionalValidationMetadatas = metadatas.filter(metadata => metadata.type == ValidationTypes.CONDITIONAL_VALIDATION);
 
             const validationError = this.generateValidationError(object, value, propertyName);
             validationErrors.push(validationError);
+
+            let canValidate = this.conditionalValidations(object, value, conditionalValidationMetadatas);
+            if (!canValidate) {
+                return;
+            }
 
             // handle IS_DEFINED validation type the special way - it should work no matter skipMissingProperties is set or not
             this.defaultValidations(object, value, definedMetadatas, validationError.constraints);
@@ -109,6 +115,14 @@ export class ValidationExecutor {
         validationError.constraints = {};
 
         return validationError;
+    }
+
+    private conditionalValidations(object: Object,
+                               value: any,
+                               metadatas: ValidationMetadata[]) {
+        return metadatas
+            .map(metadata => metadata.constraints[0](object, value))
+            .reduce((resultA, resultB) => resultA && resultB, true);
     }
 
     private defaultValidations(object: Object,

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -118,7 +118,7 @@ export class ValidationExecutor {
     }
 
     private conditionalValidations(object: Object,
-                                   value: any, 
+                                   value: any,
                                    metadatas: ValidationMetadata[]) {
         return metadatas
             .map(metadata => metadata.constraints[0](object, value))

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -118,8 +118,8 @@ export class ValidationExecutor {
     }
 
     private conditionalValidations(object: Object,
-                               value: any,
-                               metadatas: ValidationMetadata[]) {
+                                   value: any, 
+                                   metadatas: ValidationMetadata[]) {
         return metadatas
             .map(metadata => metadata.constraints[0](object, value))
             .reduce((resultA, resultB) => resultA && resultB, true);

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -55,7 +55,7 @@ export class ValidationExecutor {
             const validationError = this.generateValidationError(object, value, propertyName);
             validationErrors.push(validationError);
 
-            let canValidate = this.conditionalValidations(object, value, conditionalValidationMetadatas);
+            const canValidate = this.conditionalValidations(object, value, conditionalValidationMetadatas);
             if (!canValidate) {
                 return;
             }

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -8,6 +8,7 @@ export class ValidationTypes {
     /* system */
     static CUSTOM_VALIDATION = "customValidation";
     static NESTED_VALIDATION = "nestedValidation";
+    static CONDITIONAL_VALIDATION = "conditionalValidation";
 
     /* common checkers */
     static IS_DEFINED = "isDefined";

--- a/test/functional/conditional-validation.spec.ts
+++ b/test/functional/conditional-validation.spec.ts
@@ -1,0 +1,64 @@
+import "es6-shim";
+import {IsNotEmpty, ValidateIf} from "../../src/decorator/decorators";
+import {Validator} from "../../src/validation/Validator";
+import {ValidatorOptions} from "../../src/validation/ValidatorOptions";
+import {expect} from "chai";
+
+// -------------------------------------------------------------------------
+// Setup
+// -------------------------------------------------------------------------
+
+const validator = new Validator();
+
+// -------------------------------------------------------------------------
+// Specifications: common decorators
+// -------------------------------------------------------------------------
+
+describe("conditional validation", function() {
+    it("shouldn't validate a property when the condition is false", function() {
+        class MyClass {
+            @ValidateIf(o => false)
+            @IsNotEmpty()
+            title: string;
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(0);
+        });
+    });
+
+    it("should validate a property when the condition is true", function() {
+        class MyClass {
+            @ValidateIf(o => true)
+            @IsNotEmpty()
+            title: string = "";
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(1);
+            errors[0].target.should.be.equal(model);
+            errors[0].property.should.be.equal("title");
+            errors[0].constraints.should.be.eql({ isNotEmpty: "title should not be empty" });
+            errors[0].value.should.be.equal("");
+        });
+    });
+
+    it("should pass the object being validated to the condition function", function() {
+        class MyClass {
+            @ValidateIf(o => {
+                expect(o).to.be.instanceOf(MyClass);
+                expect(o.title).to.equal("title");
+                return true;
+            })
+            @IsNotEmpty()
+            title: string = "title";
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(0);
+        });
+    });
+});


### PR DESCRIPTION
This PR covers the addition of a potential @ValidateIf() decorator.

Definition is as follows:
```ts
@ValidateIf((object:any) => boolean)
```

The decorator can be attached to any property with validation rules, and is run by passing the object being validated to the constraint function, which returns a boolean specifying whether or not to validate that property.

Example:
```ts
export class Test {
    public conditionalProp:string;

    @ValidateIf((o:any) => o.conditionalProp == "value")
    @isNotEmpty()
    public example:string;
}

let t = new Test()
t.conditionalProp = "other";
let errors = validate(t); // -> produces error as 'example' is not empty.
t.conditionalProp = "value";
errors = validate(t); // -> produces no errors.
```

Let me know your thoughts on this, and if this is a feature you would like to add I will write tests and update the release notes.