### PR TITLE
feat: Accessing parent object when using @ValidateNested

### DIFF
--- a/src/decorator/NestedValidationOptions.ts
+++ b/src/decorator/NestedValidationOptions.ts
@@ -1,0 +1,10 @@
+/**
+ * Options used to pass to nested validation decorators.
+ */
+export interface NestedValidationOptions {
+
+    /**
+     * Specifies the property name by which the object's parent can be accessed. Defaults to 'parent'.
+     */
+    parentProperty?: string;
+}

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -6,6 +6,7 @@ import {ValidationMetadataArgs} from "../metadata/ValidationMetadataArgs";
 import {ConstraintMetadata} from "../metadata/ConstraintMetadata";
 import {getFromContainer} from "../index";
 import {MetadataStorage} from "../metadata/MetadataStorage";
+import {NestedValidationOptions} from "./NestedValidationOptions";
 
 // -------------------------------------------------------------------------
 // System
@@ -51,13 +52,14 @@ export function Validate(constraintClass: Function, constraintsOrValidationOptio
 /**
  * Objects / object arrays marked with this decorator will also be validated.
  */
-export function ValidateNested(validationOptions?: ValidationOptions) {
+export function ValidateNested(nestedValidationOptions?: NestedValidationOptions, validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.NESTED_VALIDATION,
             target: object.constructor,
             propertyName: propertyName,
-            validationOptions: validationOptions
+            constraints: [nestedValidationOptions || {}],
+            validationOptions: validationOptions,
         };
         getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
     };


### PR DESCRIPTION
Another proposal: this PR adds being able to access the parent object being validated when using the `@ValidateNested` decorator.

Example usage:

```ts
class SubPost {
    @ValidateIf(o => o.parent.example == "value")
    @IsNotEmpty()
    subExample:string;
}

class Post {
    example:string; // This is accessed by the @ValidateIf of the child class.

    @ValidateNested()
    subPost:SubPost;
}
```

This also covers the case of when the `parent` property exists and shouldn't be overwritten:

```ts
class SubPost {
    @ValidateIf(o => o.differentNameForParent.example == "value")
    @IsNotEmpty()
    subExample:string;
}

class Post {
    example:string;

    @ValidateNested({ parentProperty: "differentNameForParent" })
    subPost:SubPost;
}
```

Definition:
```ts
@ValidateNested(options?:NestedValidationOptions)
interface NestedValidationOptions {
    parentProperty?:string;
}
```

Currently if you don't specify a different `parentProperty` to the default (`"parent"`) it will overwrite any existing property; perhaps it should throw an error explaining?

As per the last feature, let me know your thoughts and any changes you think would be wise, and when you're happy I can write in the docs and tests.

Thanks! :smiley:
