### PR TITLE
adding military time validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ validator.length(str, min, max); // Checks if the string's length falls in a ran
 validator.minLength(str, min); // Checks if the string's length is not less than given number.
 validator.maxLength(str, max); // Checks if the string's length is not more than given number.
 validator.matches(str, pattern, modifiers); // Checks if string matches the pattern. Either matches('foo', /foo/i) or matches('foo', 'foo', 'i').
-validator.IsMilitaryTime(str); // Checks if the string is a valid representation of military time in the format HH:MM.
+validator.isMilitaryTime(str); // Checks if the string is a valid representation of military time in the format HH:MM.
 
 // array validation methods
 validator.arrayContains(array, values); // Checks if array contains all values from the given array of values.

--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ validator.length(str, min, max); // Checks if the string's length falls in a ran
 validator.minLength(str, min); // Checks if the string's length is not less than given number.
 validator.maxLength(str, max); // Checks if the string's length is not more than given number.
 validator.matches(str, pattern, modifiers); // Checks if string matches the pattern. Either matches('foo', /foo/i) or matches('foo', 'foo', 'i').
+validator.IsMilitaryTime(str); // Checks if the string is a valid representation of military time in the format HH:MM.
 
 // array validation methods
 validator.arrayContains(array, values); // Checks if array contains all values from the given array of values.
@@ -731,7 +732,8 @@ validator.arrayUnique(array); // Checks if all array's values are unique. Compar
 | `@Length(min: number, max?: number)`            | Checks if the string's length falls in a range.                                                                                  |
 | `@MinLength(min: number)`                       | Checks if the string's length is not less than given number.                                                                     |
 | `@MaxLength(max: number)`                       | Checks if the string's length is not more than given number.                                                                     |
-| `@Matches(pattern: RegExp, modifiers?: string)` | Checks if string matches the pattern. Either matches('foo', /foo/i) or matches('foo', 'foo', 'i').                               |
+| `@Matches(pattern: RegExp, modifiers?: string)` | Checks if string matches the pattern. Either matches('foo', /foo/i) or matches('foo', 'foo', 'i').
+| `@IsMilitaryTime()`                             | Checks if the string is a valid representation of military time in the format HH:MM.
 | **Array validation decorators**                                                                                                                                                    |
 | `@ArrayContains(values: any[])`                 | Checks if array contains all values from the given array of values.                                                              |
 | `@ArrayNotContains(values: any[])`              | Checks if array does not contain any of the given values.                                                                        |

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -3,6 +3,7 @@
 **0.6.3**
 
 * added `validateOrReject` method which rejects promise instead of returning array of errors in resolved result
+* added `@IsMilitaryTime` decorator.
 
 **0.6.1**
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,9 +1,12 @@
 # Release notes
 
+**0.6.4**
+
+* added `@IsMilitaryTime` decorator.
+
 **0.6.3**
 
 * added `validateOrReject` method which rejects promise instead of returning array of errors in resolved result
-* added `@IsMilitaryTime` decorator.
 
 **0.6.1**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "class-validator",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Class-based validation with Typescript / ES6 / ES5 using decorators or validation schemas. Supports both node.js and browser",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -976,6 +976,21 @@ export function Matches(pattern: RegExp, modifiersOrAnnotationOptions?: string|V
     };
 }
 
+/**
+ * Checks if the string correctly represents a time in the format HH:MM 
+ */
+export function IsMilitaryTime(validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.IS_MILITARY_TIME,
+            target: object.constructor,
+            propertyName: propertyName,
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
 // -------------------------------------------------------------------------
 // Array checkers
 // -------------------------------------------------------------------------

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -77,6 +77,7 @@ export class ValidationTypes {
     static MIN_LENGTH = "minLength";
     static MAX_LENGTH = "maxLength";
     static MATCHES = "matches";
+    static IS_MILITARY_TIME = "isTimeValue";
 
     /* array checkers */
     static ARRAY_CONTAINS = "arrayContains";

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -77,7 +77,7 @@ export class ValidationTypes {
     static MIN_LENGTH = "minLength";
     static MAX_LENGTH = "maxLength";
     static MATCHES = "matches";
-    static IS_MILITARY_TIME = "isTimeValue";
+    static IS_MILITARY_TIME = "isMilitaryTime";
 
     /* array checkers */
     static ARRAY_CONTAINS = "arrayContains";

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -228,6 +228,8 @@ export class Validator {
                 return this.maxLength(value, metadata.constraints[0]);
             case ValidationTypes.MATCHES:
                 return this.matches(value, metadata.constraints[0], metadata.constraints[1]);
+            case ValidationTypes.IS_MILITARY_TIME:
+                return this.isMilitaryTime(value);
 
             /* array checkers */
             case ValidationTypes.ARRAY_CONTAINS:
@@ -703,6 +705,14 @@ export class Validator {
      */
     matches(value: string, pattern: RegExp, modifiers?: string): boolean {
         return typeof value === "string" && this.validatorJs.matches(value, pattern, modifiers);
+    }
+
+    /**
+     * Checks if the string represents a time without a given timezone in the format HH:MM (military)
+     * If the given value does not match the pattern HH:MM, then it returns false.
+     */
+    isMilitaryTime(value: string): boolean {
+        return this.matches(value, /^([01]\d|2[0-3]):?([0-5]\d)$/);
     }
     
     // -------------------------------------------------------------------------

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -46,6 +46,7 @@ import {
     Min,
     Max,
     IsNotEmpty,
+    IsMilitaryTime,
     ArrayNotEmpty,
     ArrayMinSize,
     ArrayMaxSize,
@@ -2772,6 +2773,30 @@ describe("Matches", function() {
         const validationType = "matches";
         const message = "someProperty must match " + constraint + " regular expression";
         checkReturnedError(new MyClass(), invalidValues, validationType, message, done);
+    });
+
+});
+
+describe("IsMilitaryTime", function() {
+
+    class MyClass {
+        @IsMilitaryTime()
+        someProperty: string;
+    }
+
+    it("should not fail for a valid time in the format HH:MM", function(done) {
+        const validValues = ["10:22", "12:03", "16:32", "23:59", "00:00"];
+        checkValidValues(new MyClass(), validValues, done);
+    });
+
+    it("should fail for invalid time format", function(done) {
+        const invalidValues = ["23:61", "25:00", "08:08 pm", "04:00am"];
+        checkInvalidValues(new MyClass(), invalidValues, done);
+    });
+
+    it("should fail for invalid values", function(done) {
+        const invalidValues = [undefined, null, "23:00 and invalid counterpart"];
+        checkInvalidValues(new MyClass(), invalidValues, done);
     });
 
 });


### PR DESCRIPTION
I've run into a use case whereby I'd like to validate the text of an input field being in military time format. This is support by some browsers - please see the MDN docs for time with input https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

However, there is insufficient support across all browsers for this use case. 

It uses a relatively complex regex, and rather than using the matchers validator, this would be somewhat less error-prone and easier to use.