### PR TITLE
fix ValidateNested() when value is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "class-validator",
   "private": true,
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "Class-based validation with Typescript / ES6 / ES5 using decorators or validation schemas. Supports both node.js and browser",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "class-validator",
+  "name": "sw-class-validator",
   "private": true,
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Class-based validation with Typescript / ES6 / ES5 using decorators or validation schemas. Supports both node.js and browser",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -11,10 +11,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pleerock/class-validator.git"
+    "url": "https://github.com/swanest/class-validator.git"
   },
   "bugs": {
-    "url": "https://github.com/pleerock/class-validator/issues"
+    "url": "https://github.com/swanest/class-validator/issues"
   },
   "tags": [
     "validator",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sw-class-validator",
+  "name": "class-validator",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.7.0",
   "description": "Class-based validation with Typescript / ES6 / ES5 using decorators or validation schemas. Supports both node.js and browser",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -11,10 +11,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/swanest/class-validator.git"
+    "url": "https://github.com/pleerock/class-validator.git"
   },
   "bugs": {
-    "url": "https://github.com/swanest/class-validator/issues"
+    "url": "https://github.com/pleerock/class-validator/issues"
   },
   "tags": [
     "validator",

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -53,6 +53,7 @@ export function Validate(constraintClass: Function, constraintsOrValidationOptio
  */
 export function ValidateNested(validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
+        IsDefined()(object, propertyName);
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.NESTED_VALIDATION,
             target: object.constructor,

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -53,7 +53,6 @@ export function Validate(constraintClass: Function, constraintsOrValidationOptio
  */
 export function ValidateNested(validationOptions?: ValidationOptions) {
     return function (object: Object, propertyName: string) {
-        IsDefined()(object, propertyName);
         const args: ValidationMetadataArgs = {
             type: ValidationTypes.NESTED_VALIDATION,
             target: object.constructor,

--- a/src/validation/ValidationExecutor.ts
+++ b/src/validation/ValidationExecutor.ts
@@ -184,6 +184,11 @@ export class ValidationExecutor {
     }
     
     private nestedValidations(value: any, metadatas: ValidationMetadata[], errors: ValidationError[]) {
+
+        if (value === void 0) {
+            return;
+        }
+
         metadatas.forEach(metadata => {
             if (metadata.type !== ValidationTypes.NESTED_VALIDATION) return;
             const targetSchema = typeof metadata.target === "string" ? metadata.target as string : undefined;

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -1,5 +1,5 @@
 import "es6-shim";
-import {Contains, MinLength, ValidateNested} from "../../src/decorator/decorators";
+import {Contains, MinLength, ValidateNested, IsDefined} from "../../src/decorator/decorators";
 import {Validator} from "../../src/validation/Validator";
 import {ValidatorOptions} from "../../src/validation/ValidatorOptions";
 import {expect} from "chai";
@@ -27,7 +27,7 @@ describe("nested validation", function () {
             @Contains("hello")
             title: string;
 
-            @ValidateNested()
+            @ValidateNested() @IsDefined()
             mySubClass: MySubClass;
         }
 

--- a/test/functional/nested-validation.spec.ts
+++ b/test/functional/nested-validation.spec.ts
@@ -14,9 +14,36 @@ const validator = new Validator();
 // Specifications: common decorators
 // -------------------------------------------------------------------------
 
-describe("nested validation", function() {
+describe("nested validation", function () {
 
-    it("should validate nested objects", function() {
+    it("should not validate missing nested objects", function () {
+
+        class MySubClass {
+            @MinLength(5)
+            name: string;
+        }
+
+        class MyClass {
+            @Contains("hello")
+            title: string;
+
+            @ValidateNested()
+            mySubClass: MySubClass;
+        }
+
+        const model: any = new MyClass();
+
+        model.title = "helo";
+        return validator.validate(model).then(errors => {
+            errors[1].target.should.be.equal(model);
+            expect(errors[1].value).to.be.undefined;
+            errors[1].property.should.be.equal("mySubClass");
+            errors[1].constraints.should.be.eql({isDefined: "mySubClass should not be null or undefined"});
+        });
+    });
+
+
+    it("should validate nested objects", function () {
 
         class MySubClass {
             @MinLength(5)


### PR DESCRIPTION
Putting `@ValidateNested()` above missing value throws an error. Now, it first checks whether the value exists. Handy to check schemas sent via http.