### PR TITLE
Feature - Adding IsEnum validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ validator.isString(value); // Checks if a given value is a real string.
 validator.isArray(value); // Checks if a given value is an array.
 validator.isNumber(value); // Checks if a given value is a real number.
 validator.isInt(value); // Checks if value is an integer.
+validator.isEnum(value, entity); // Checks if value is valid for a certain enum entity.
 
 // number validation methods
 validator.isDivisibleBy(value, num); // Checks if value is a number that's divisible by another.
@@ -685,6 +686,7 @@ validator.arrayUnique(array); // Checks if all array's values are unique. Compar
 | `@IsNumber()`                                   | Checks if the string is a number.                                                                                                |
 | `@IsInt()`                                      | Checks if the value is an integer number.                                                                                        |
 | `@IsArray()`                                    | Checks if the string is an array                                                                                                 |
+| `@Enum(entity: object)`                         | Checks if the value is an valid enum                                                                                             |
 | **Number validation decorators**                                                                                                                                                   |
 | `@IsDivisibleBy(num: number)`                   | Checks if the value is a number that's divisible by another.                                                                     |
 | `@IsPositive()`                                 | Checks if the value is a positive number.                                                                                        |

--- a/sample/sample1-simple-validation/Post.ts
+++ b/sample/sample1-simple-validation/Post.ts
@@ -1,4 +1,9 @@
-import {Contains, IsInt, MinLength, MaxLength, IsEmail, IsFQDN, IsDate, ArrayNotEmpty, ArrayMinSize, ArrayMaxSize} from "../../src/decorator/decorators";
+import {Contains, IsInt, MinLength, MaxLength, IsEmail, IsFQDN, IsDate, ArrayNotEmpty, ArrayMinSize, ArrayMaxSize, IsEnum} from "../../src/decorator/decorators";
+
+export enum PostType {
+    Public,
+    Private
+}
 
 export class Post {
 
@@ -28,4 +33,6 @@ export class Post {
     @MaxLength(50, { each: true, message: "Tag is too long. Maximal length is $value characters" })
     tags: string[];
 
+    @IsEnum(PostType)
+    type: PostType;
 }

--- a/sample/sample1-simple-validation/app.ts
+++ b/sample/sample1-simple-validation/app.ts
@@ -136,7 +136,7 @@ post10.email = "info@google.com"; // should pass
 post10.site = "google.com"; // should pass
 post10.createDate = new Date(); // should pass
 post10.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"];
-post10.type = PostType.Private
+post10.type = PostType.Private;
 
 validate(post10).then(result => {
     console.log("10. should pass: ", result); // should pass

--- a/sample/sample1-simple-validation/app.ts
+++ b/sample/sample1-simple-validation/app.ts
@@ -1,5 +1,5 @@
 import {validate} from "../../src/index";
-import {Post} from "./Post";
+import {Post, PostType} from "./Post";
 
 // Sample1. simple validation
 
@@ -11,6 +11,7 @@ post1.email = "info@google.com"; // should pass
 post1.site = "google.com"; // should pass
 post1.createDate = new Date(); // should pass
 post1.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"]; // should pass
+post1.type = PostType.Private;
 
 validate(post1).then(result => {
     console.log("1. should pass: ", result); // should pass completely, e.g. return empty array
@@ -22,6 +23,7 @@ post2.text = "this is a great post about hell world"; // should not pass
 post2.rating = 11; // should not pass
 post2.email = "google.com"; // should not pass
 post2.site = "googlecom"; // should not pass
+post2.type = PostType.Private;
 // should not pass because date property is missing
 
 validate(post2).then(result => {
@@ -36,6 +38,7 @@ post3.text = "this is a great post about hell world"; // should not pass
 post3.rating = 11; // should not pass
 post3.email = "google.com"; // should not pass
 post3.site = "googlecom"; // should not pass
+post3.type = PostType.Private;
 
 validate(post3, { skipMissingProperties: true }).then(result => {
     console.log("3. should not pass: ", result); // should not pass, but returned ValidationError-s should not have error about date field
@@ -47,6 +50,7 @@ post4.text = "this is a great post about hello world"; // should pass
 post4.rating = 10; // should pass
 post4.email = "info@google.com"; // should pass
 post4.site = "google.com"; // should pass
+post4.type = PostType.Private;
 
 validate(post4, { skipMissingProperties: true }).then(result => {
     console.log("4. should pass: ", result); // should pass even if date is not set
@@ -60,6 +64,7 @@ post5.text = "this is a great post about hello world"; // should pass
 post5.rating = 10; // should pass
 post5.email = "info@google.com"; // should pass
 post5.site = "google.com"; // should pass
+post5.type = PostType.Private;
 
 validate(post5, { skipMissingProperties: true }).then(result => {
     console.log("5. should pass: ", result); // should pass even if date is not set
@@ -75,6 +80,7 @@ post6.email = "info@google.com"; // should pass
 post6.site = "google.com"; // should pass
 post6.createDate = new Date(); // should pass
 post6.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"];
+post6.type = PostType.Private;
 
 validate(post6).then(result => {
     console.log("6. should pass: ", result); // should pass completely, e.g. return empty array
@@ -88,6 +94,7 @@ post7.email = "info@google.com"; // should pass
 post7.site = "google.com"; // should pass
 post7.createDate = new Date(); // should pass
 post7.tags = ["news", "a"];
+post7.type = PostType.Private;
 
 validate(post7).then(result => {
     console.log("7. should not pass: ", result); // should not pass
@@ -101,6 +108,7 @@ post8.email = "info@google.com"; // should pass
 post8.site = "google.com"; // should pass
 post8.createDate = new Date(); // should pass
 post8.tags = [];
+post8.type = PostType.Private;
 
 validate(post8).then(result => {
     console.log("8. should not pass: ", result); // should not pass
@@ -114,6 +122,7 @@ post9.email = "info@google.com"; // should pass
 post9.site = "google.com"; // should pass
 post9.createDate = new Date(); // should pass
 post9.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4", "abcd4"];
+post9.type = PostType.Private;
 
 validate(post9).then(result => {
     console.log("9. should not pass: ", result); // should not pass
@@ -127,6 +136,7 @@ post10.email = "info@google.com"; // should pass
 post10.site = "google.com"; // should pass
 post10.createDate = new Date(); // should pass
 post10.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"];
+post10.type = PostType.Private
 
 validate(post10).then(result => {
     console.log("10. should pass: ", result); // should pass
@@ -140,7 +150,22 @@ post11.email = "info@google.com"; // should pass
 post11.site = "google.com"; // should pass
 post11.createDate = new Date(); // should pass
 post11.tags = null;
+post11.type = PostType.Private;
 
 validate(post11).then(result => {
     console.log("11. should not pass: ", result); // should not pass
+});
+
+let post12 = new Post();
+post12.title = "Hello world"; // should pass
+post12.text = "this is a great post about hello world"; // should pass
+post12.rating = 10; // should pass
+post12.email = "info@google.com"; // should pass
+post12.site = "google.com"; // should pass
+post12.createDate = new Date(); // should pass
+post12.tags = ["abcd1", "abcd2", "abcd3", "abcd4", "abcd4"]; // should pass
+post12.type = 99; // should not pass
+
+validate(post1).then(result => {
+    console.log("12. should not pass: ", result); // should not pass as type is not a valid enum
 });

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -286,6 +286,23 @@ export function IsArray(validationOptions?: ValidationOptions) {
     };
 }
 
+/**
+ * Checks if a value is a number enum.
+ */
+export function IsEnum(entity: Object, validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.IS_ENUM,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [entity],
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
+
 // -------------------------------------------------------------------------
 // Number checkers
 // -------------------------------------------------------------------------

--- a/src/validation/ValidationTypes.ts
+++ b/src/validation/ValidationTypes.ts
@@ -26,6 +26,7 @@ export class ValidationTypes {
     static IS_STRING = "isString";
     static IS_ARRAY = "isArray";
     static IS_INT = "isInt";
+    static IS_ENUM = "isEnum";
 
     /* number checkers */
     static IS_DIVISIBLE_BY = "isDivisibleBy";
@@ -132,6 +133,8 @@ export class ValidationTypes {
                 return eachPrefix + "$property must be a string";
             case this.IS_ARRAY:
                 return eachPrefix + "$property must be an array";
+            case this.IS_ENUM:
+                return eachPrefix + "$property must be a valid enum value";
 
             /* number checkers */
             case this.IS_DIVISIBLE_BY:

--- a/src/validation/Validator.ts
+++ b/src/validation/Validator.ts
@@ -134,6 +134,8 @@ export class Validator {
                 return this.isNumber(value);
             case ValidationTypes.IS_INT:
                 return this.isInt(value);
+            case ValidationTypes.IS_ENUM:
+                return this.isEnum(value, metadata.constraints[0]);
 
             /* number checkers */
             case ValidationTypes.IS_DIVISIBLE_BY:
@@ -331,6 +333,16 @@ export class Validator {
      */
     isArray(value: any): boolean {
         return value instanceof Array;
+    }
+
+     /**
+     * Checks if a given value is an enum
+     */
+    isEnum(value: any, entity: any): boolean {
+        const enumValues = Object.keys(entity)
+            .map(k => entity[k])
+            .filter(v => typeof v === "number") as number[];
+        return enumValues.indexOf(value) >= 0;
     }
 
     /**

--- a/test/functional/validation-functions-and-decorators.spec.ts
+++ b/test/functional/validation-functions-and-decorators.spec.ts
@@ -19,6 +19,7 @@ import {
     IsDate,
     IsDivisibleBy,
     IsEmail,
+    IsEnum,
     IsFQDN,
     IsFullWidth,
     IsHalfWidth,
@@ -606,6 +607,55 @@ describe("IsArray", function() {
     });
 
 });
+
+
+describe.only("IsEnum", function() {
+
+    enum MyEnum {
+        First   = 1,
+        Second  = 999
+    }
+
+    const validValues = [MyEnum.First, MyEnum.Second];
+    const invalidValues = [
+        true,
+        false,
+        0,
+        {},
+        null,
+        undefined,
+        "First"
+    ];
+
+    class MyClass {
+        @IsEnum(MyEnum)
+        someProperty: MyEnum;
+    }
+
+    it("should not fail if validator.validate said that its valid", function(done) {
+        checkValidValues(new MyClass(), validValues, done);
+    });
+
+    it("should fail if validator.validate said that its invalid", function(done) {
+        checkInvalidValues(new MyClass(), invalidValues, done);
+    });
+
+    it("should not fail if method in validator said that its valid", function() {
+        validValues.forEach(value => validator.isEnum(value, MyEnum).should.be.true);
+    });
+
+    it("should fail if method in validator said that its invalid", function() {
+        invalidValues.forEach(value => validator.isEnum(value, MyEnum).should.be.false);
+    });
+
+    it("should return error object with proper data", function(done) {
+        const validationType = "isEnum";
+        const message = "someProperty must be a valid enum value";
+        checkReturnedError(new MyClass(), invalidValues, validationType, message, done);
+    });
+
+});
+
 
 // -------------------------------------------------------------------------
 // Specifications: number check


### PR DESCRIPTION
Adding enum validation decorator.

Currently there was no way of validating if a value was a valid enum and I noticed developers resorting to _hacky_ solutions like using `@Min` and `@Max` decorators to make sure value was inside the enum range. 

This PR solution aims to ease the validation of enums with number values.

Example usage

```
class MyClass {
  @IsEnum(MyEnum)
  someProperty: MyEnum;
}
```


