### PR TITLE
Add IsOptional() decorator: if value missing, validators ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,7 @@ validator.arrayUnique(array); // Checks if all array's values are unique. Compar
 |-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | **Common validation decorators**                                                                                                                                                   |
 | `@IsDefined(value: any)`                        | Checks if value is defined (!== undefined, !== null). This is the only decorator that ignores skipMissingProperties option.      |
+| `@IsOptional()`                                 | Checks if given value is empty (=== '', === null) and if so, ignores all the validators on the property.                         |
 | `@Equals(comparison: any)`                      | Checks if value equals ("===") comparison.                                                                                       |
 | `@NotEquals(comparison: any)`                   | Checks if value not equal ("!==") comparison.                                                                                    |
 | `@IsEmpty()`                                    | Checks if given value is empty (=== '', === null, === undefined).                                                                |

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -192,6 +192,24 @@ export function IsNotIn(values: any[], validationOptions?: ValidationOptions) {
     };
 }
 
+/**
+ * Checks if value is missing and if so, ignores all validators.
+ */
+export function IsOptional(validationOptions?: ValidationOptions) {
+    return function (object: Object, propertyName: string) {
+        const args: ValidationMetadataArgs = {
+            type: ValidationTypes.CONDITIONAL_VALIDATION,
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [(object: any, value: any) => {
+                return object[propertyName] !== "" && object[propertyName] !== null;
+            }],
+            validationOptions: validationOptions
+        };
+        getFromContainer(MetadataStorage).addValidationMetadata(new ValidationMetadata(args));
+    };
+}
+
 // -------------------------------------------------------------------------
 // Type checkers
 // -------------------------------------------------------------------------

--- a/test/functional/conditional-validation.spec.ts
+++ b/test/functional/conditional-validation.spec.ts
@@ -1,5 +1,5 @@
 import "es6-shim";
-import {IsNotEmpty, ValidateIf} from "../../src/decorator/decorators";
+import {IsNotEmpty, ValidateIf, IsOptional, Equals} from "../../src/decorator/decorators";
 import {Validator} from "../../src/validation/Validator";
 import {ValidatorOptions} from "../../src/validation/ValidatorOptions";
 import {expect} from "chai";
@@ -59,6 +59,36 @@ describe("conditional validation", function() {
         const model = new MyClass();
         return validator.validate(model).then(errors => {
             errors.length.should.be.equal(0);
+        });
+    });
+
+    it("should not validate a property when value is empty", function () {
+        class MyClass {
+            @IsOptional()
+            @Equals("test")
+            title: string = "";
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(0);
+        });
+    });
+
+    it("should validate a property when value is supplied", function () {
+        class MyClass {
+            @IsOptional()
+            @Equals("test")
+            title: string = "bad_value";
+        }
+
+        const model = new MyClass();
+        return validator.validate(model).then(errors => {
+            errors.length.should.be.equal(1);
+            errors[0].target.should.be.equal(model);
+            errors[0].property.should.be.equal("title");
+            errors[0].constraints.should.be.eql({ equals: "title must be equal to test" });
+            errors[0].value.should.be.equal("bad_value");
         });
     });
 });


### PR DESCRIPTION
This PR adds a new decorator `@IsOptional()` which checks if a value is is empty (=== '', === null) and if so, ignores all the validators on the property.

This decorator is equivalent to `@ValidateIf` with a condition checking for a missing value.  Example:

```
@ValidateIf((o)=> o.email !== "" && o.email !== null)
email: string;
```

This allows for a value to be completely optional for the purpose of validation, but if supplied, to be validated with existing validators.