### PR TITLE
@IsOptional() and skipMissingProperties should have similar behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ validator.arrayUnique(array); // Checks if all array's values are unique. Compar
 |-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
 | **Common validation decorators**                                                                                                                                                   |
 | `@IsDefined(value: any)`                        | Checks if value is defined (!== undefined, !== null). This is the only decorator that ignores skipMissingProperties option.      |
-| `@IsOptional()`                                 | Checks if given value is empty (=== '', === null, === undefined) and if so, ignores all the validators on the property.                         |
+| `@IsOptional()`                                 | Checks if given value is empty (=== null, === undefined) and if so, ignores all the validators on the property.                         |
 | `@Equals(comparison: any)`                      | Checks if value equals ("===") comparison.                                                                                       |
 | `@NotEquals(comparison: any)`                   | Checks if value not equal ("!==") comparison.                                                                                    |
 | `@IsEmpty()`                                    | Checks if given value is empty (=== '', === null, === undefined).                                                                |

--- a/src/decorator/decorators.ts
+++ b/src/decorator/decorators.ts
@@ -202,7 +202,7 @@ export function IsOptional(validationOptions?: ValidationOptions) {
             target: object.constructor,
             propertyName: propertyName,
             constraints: [(object: any, value: any) => {
-                return object[propertyName] !== "" && object[propertyName] !== null && object[propertyName] !== undefined;
+                return object[propertyName] !== null && object[propertyName] !== undefined;
             }],
             validationOptions: validationOptions
         };

--- a/test/functional/conditional-validation.spec.ts
+++ b/test/functional/conditional-validation.spec.ts
@@ -62,7 +62,7 @@ describe("conditional validation", function() {
         });
     });
 
-    it("should not validate a property when value is empty", function () {
+    it("should validate a property when value is empty", function () {
         class MyClass {
             @IsOptional()
             @Equals("test")
@@ -71,7 +71,11 @@ describe("conditional validation", function() {
 
         const model = new MyClass();
         return validator.validate(model).then(errors => {
-            errors.length.should.be.equal(0);
+            errors.length.should.be.equal(1);
+            errors[0].target.should.be.equal(model);
+            errors[0].property.should.be.equal("title");
+            errors[0].constraints.should.be.eql({ equals: "title must be equal to test" });
+            errors[0].value.should.be.equal("bad_value");
         });
     });
 

--- a/test/functional/conditional-validation.spec.ts
+++ b/test/functional/conditional-validation.spec.ts
@@ -75,7 +75,7 @@ describe("conditional validation", function() {
             errors[0].target.should.be.equal(model);
             errors[0].property.should.be.equal("title");
             errors[0].constraints.should.be.eql({ equals: "title must be equal to test" });
-            errors[0].value.should.be.equal("bad_value");
+            errors[0].value.should.be.equal("");
         });
     });
 


### PR DESCRIPTION
Allowing empty string in `@IsOptional ` opens a security hole in validation for datatypes other than string type. Additionally, it should behave similarly to "skipMissingProperties" which also skips validation only when the property is null or undefined